### PR TITLE
Center group photo and heading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -335,7 +335,7 @@ hr.soft {
 /*color: #900; */
 }
 .pubv {
-/*  color: #090;*/
+/* color: #090;*/
 /*color: #900;*/
  font-style: italic;
   font-size: 14px;
@@ -914,7 +914,7 @@ body.has-fixed-header main {
 .hero-intro h1 {
   font-size: clamp(2.4rem, 4.8vw, 3.35rem);
   line-height: 1.08;
-  max-width: 32rem;
+  white-space: nowrap;
   margin-bottom: 1rem;
 }
 
@@ -941,7 +941,8 @@ body.has-fixed-header main {
 }
 
 .hero-group-photo {
-  max-width: clamp(320px, 34vw, 560px);
+  width: 100%;
+  max-width: 100%;
   border-radius: 0.5rem;
   padding: 0;
   background: none;
@@ -1040,7 +1041,7 @@ body.has-fixed-header main {
 
 @media (max-width: 991.98px) {
   .hero-group-photo {
-    max-width: clamp(280px, 80vw, 520px);
+    /* max-width: clamp(280px, 80vw, 520px); */ /* Diese Zeile ist nicht mehr nötig */
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
   <section class="hero-intro py-5 border-bottom bg-white">
     <div class="container">
       <div class="row g-5 align-items-center">
-        <div class="col-lg-7">
-          <h1 class="display-5 fw-semibold text-dark">Artificial Intelligence &amp; Machine Learning Lab </h1>
+        <div class="col-lg-12">
+          <h1 class="display-5 fw-semibold text-dark text-center">Artificial Intelligence &amp; Machine Learning Lab </h1>
           <p class="text-uppercase text-muted fw-semibold small letter-spacing">TU Darmstadt</p>
           <p class="lead text-secondary mt-3">We advance statistical learning, probabilistic reasoning, and collaborative intelligence to enable systems that can understand complex worlds and act responsibly.</p>
           <div class="d-flex flex-wrap gap-3 align-items-center mt-4">
@@ -56,7 +56,7 @@
           </div>
           <div class="hero-stats mt-4" data-render="heroStats"></div>
         </div>
-        <div class="col-lg-5">
+        <div class="col-lg-12 mt-4">
       <figure class="hero-figure">
             <div class="hero-group-photo-wrapper" data-component="heroPhoto">
               <button type="button" class="hero-group-photo-toggle" data-action="toggleHeroPhoto" aria-expanded="false" aria-label="Toggle enlarged group photo">


### PR DESCRIPTION

Hi, I centered the group photo and the main heading.
Do you prefer this change?

Before:
<img width="1127" height="656" alt="Screenshot 2025-11-17 at 17 32 51" src="https://github.com/user-attachments/assets/b1bf3cdf-5586-43d5-886f-27ab5b40ff77" />

After:
<img width="952" height="698" alt="Screenshot 2025-11-17 at 17 33 25" src="https://github.com/user-attachments/assets/157f2971-348f-465a-bfa2-cf1967c7da83" />
