### PR TITLE
fix: update dmml, dlam metadata semester to Summer 2026

### DIFF
--- a/build/site-content.js
+++ b/build/site-content.js
@@ -37,8 +37,8 @@ window.AIML_SITE_CONTENT = {
       "credits": "6 CP",
       "recommended": "Bachelor 4th semester or later.",
       "language": "English",
-      "lastTaught": "Summer 2025",
-      "link": "./lectures/dmml2025sose/index.html",
+      "lastTaught": "Summer 2026",
+      "link": "./lectures/dmml2026sose/index.html",
       "responsible": ["Course team"]
     },
     {
@@ -50,8 +50,8 @@ window.AIML_SITE_CONTENT = {
       "credits": "6 CP",
       "recommended": "After DMML or equivalent.",
       "language": "English",
-      "lastTaught": "Summer 2025",
-      "link": "./lectures/dl2025sose/index.html",
+      "lastTaught": "Summer 2026",
+      "link": "./lectures/dl2026sose/index.html",
       "responsible": ["Course team"]
     },
     {


### PR DESCRIPTION
bumps the lastTaught field from 2025 to 2026 for DMML and DLAM. it fixes the main page redirection so it correctly routes to the existing 2026sose course directories.